### PR TITLE
Starting Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: xenial
+sudo: false
+git:
+  quiet: true
+language: java
+addons:
+  apt:
+    config:
+      retries: true
+    update: true
+    packages:
+      - ant
+jdk:
+  - openjdk11
+  - openjdk10
+  - openjdk9
+  - openjdk8
+matrix:
+  allow_failures:
+    - jdk: openjdk11
+    - jdk: openjdk10
+    - jdk: openjdk9
+  fast_finish: true
+script: ant

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # FastQC
+
+[![Travis Build Status](https://travis-ci.org/s-andrews/FastQC.svg?branch=master)](https://travis-ci.org/s-andrews/FastQC)
+
 FastQC is a program designed to spot potential problems in high througput sequencing datasets.  It runs a set of analyses on one or more raw sequence files in fastq or bam format and produces a report which summarises the results.
 
 ![FastQC Screenshot](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc.png)


### PR DESCRIPTION
Hello Simon.
I faced a build error on JDK 10 ARM-64 environment.

```
$ ant
Buildfile: /home/travis/build/junaruga/FastQC/build.xml
build-subprojects:
init:
    [mkdir] Created dir: /home/travis/build/junaruga/FastQC/bin
     [copy] Copying 60 files to /home/travis/build/junaruga/FastQC/bin
build-project:
     [echo] FastQC: /home/travis/build/junaruga/FastQC/build.xml
    [javac] Compiling 136 source files to /home/travis/build/junaruga/FastQC/bin
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 5
    [javac] error: Source option 5 is no longer supported. Use 6 or later.
    [javac] error: Target option 1.5 is no longer supported. Use 1.6 or later.
```

Then I realized this repository does not have CI environment.
So, I prepared Travis CI environment for this repository.
Shall we start Travis CI for this repository?
It's useful to detect an issue for covered platforms.

See below results on JDK 8, 9, 10, and 11.
https://travis-ci.org/junaruga/FastQC/builds/494486515
The build is succeeded for JDK 8. But failed for JDK 9, 10,  and 11.

You can just start your Travis CI on this repository enabling it from below page.
https://travis-ci.org/s-andrews/FastQC

Thank you.