### PR TITLE
Add colourblind friendly palletes, activated with --colourblind

### DIFF
--- a/fastqc
+++ b/fastqc
@@ -104,6 +104,7 @@ my $kmer_size;
 my $temp_directory;
 my $min_length;
 my $dup_length;
+my $colourblind;
 
 my $result = GetOptions('version' => \$version,
 						'help' => \$help,
@@ -125,6 +126,7 @@ my $result = GetOptions('version' => \$version,
 						'java=s' => \$java_bin,
 						'min_length=i' => \$min_length,
 						'dup_length=i' => \$dup_length,
+						'colourblind' => \$colourblind,
 						 );
 
 # Check the simple stuff first
@@ -186,6 +188,9 @@ if ($dup_length) {
 	push @java_args ,"-Dfastqc.dup_length=$dup_length";
 }
 
+if ($colourblind) {
+	push @java_args ,"-Dfastqc.colourblind=true";
+}
 
 if ($threads) {
 	if ($threads < 1) {
@@ -439,6 +444,7 @@ DESCRIPTION
                     generating report images. Defaults to system temp directory if
                     not specified.
                     
+   --colourblind    Uses colourblind-friendly palette when plotting graphs
 BUGS
 
     Any bugs in fastqc should be reported either to simon.andrews@babraham.ac.uk

--- a/uk/ac/babraham/FastQC/Graphs/LineGraph.java
+++ b/uk/ac/babraham/FastQC/Graphs/LineGraph.java
@@ -40,6 +40,7 @@ public class LineGraph extends JPanel {
 	private double yInterval;
 	
 	private static final Color [] COLOURS = new Color[] {new Color(220,0,0), new Color(0,0,220), new Color(0,220,0), Color.DARK_GRAY, Color.MAGENTA, Color.ORANGE,Color.YELLOW,Color.CYAN,Color.PINK,Color.LIGHT_GRAY};
+	private static final Color [] CBCOLOURS = new Color[] {new Color(238,136,102),new Color(170,170,0), new Color(68,187,153), new Color(119,170,221), new Color(238,221,136),new Color(187,204,51),new Color(153,221,255),new Color(221,221,221), new Color(85,85,85), Color.BLACK};
 	
 	public LineGraph (double [] [] data, double minY, double maxY, String xLabel, String [] xTitles, int [] xCategories, String graphTitle) {
 		this(data,minY,maxY,xLabel,xTitles,new String[0],graphTitle);
@@ -93,6 +94,14 @@ public class LineGraph extends JPanel {
 	
 	public void paint (Graphics g) {
 		super.paint(g);
+
+		Color [] PALETTE;
+
+		if (System.getProperty("fastqc.colourblind")!=null && System.getProperty("fastqc.colourblind").equals("true")) {
+			PALETTE = CBCOLOURS;
+		} else {
+			PALETTE = COLOURS;
+		}
 		
 		g.setColor(Color.WHITE);
 		g.fillRect(0, 0, getWidth(), getHeight());
@@ -182,7 +191,7 @@ public class LineGraph extends JPanel {
 		}
 		
 		for (int d=0;d<data.length;d++) {
-			g.setColor(COLOURS[d % COLOURS.length]);
+			g.setColor(PALETTE[d % PALETTE.length]);
 			
 			if (data[d].length > 0)
 				lastY = getY(data[d][0]);
@@ -220,7 +229,7 @@ public class LineGraph extends JPanel {
 
 		// Now draw the actual labels
 		for (int t=0;t<xTitles.length;t++) {
-			g.setColor(COLOURS[t % COLOURS.length]);
+			g.setColor(PALETTE[t % PALETTE.length]);
 			g.drawString(xTitles[t], ((getWidth()-10)-widestLabel)+3, 40+(20*(t+1)));
 		}
 		

--- a/uk/ac/babraham/FastQC/Graphs/QualityBoxPlot.java
+++ b/uk/ac/babraham/FastQC/Graphs/QualityBoxPlot.java
@@ -45,6 +45,11 @@ public class QualityBoxPlot extends JPanel {
 	private static final Color GOOD_DARK = new Color(175,230,175);
 	private static final Color BAD_DARK = new Color(230,215,175);
 	private static final Color UGLY_DARK = new Color(230,175,175);
+
+	//CB-friendly colours from https://personal.sron.nl/~pault/#sec:qualitative
+	private static final Color CB_GOOD = new Color(204,221,170);
+	private static final Color CB_BAD = new Color(238,238,187);
+	private static final Color CB_UGLY = new Color(255,204,204);
 		
 	public QualityBoxPlot (double [] means, double [] medians, double [] lowest, double [] highest, double [] lowerQuartile, double [] upperQuartile, double minY, double maxY, double yInterval, String [] xLabels, String graphTitle) {
 
@@ -114,45 +119,71 @@ public class QualityBoxPlot extends JPanel {
 		// First draw faint boxes over alternating bases so you can see which is which
 		
 		int lastXLabelEnd = 0;
-		
-		for (int i=0;i<means.length;i++) {		// Now draw some background colours which show good / bad quality
-			if (i%2 != 0) {
-				g.setColor(UGLY);
-			}
-			else {
-				g.setColor(UGLY_DARK);
-			}
 
-			g.fillRect(xOffset+(baseWidth*i), getY(20), baseWidth, getY(yStart)-getY(20));
+		if (System.getProperty("fastqc.colourblind")!=null && System.getProperty("fastqc.colourblind").equals("true")) { 
+			// Colourblind friendly background colours
+			for (int i=0;i<means.length;i++) {		// Now draw some background colours which show good / bad quality
 
-			if (i%2 != 0) {
-				g.setColor(BAD);
+				g.setColor(CB_UGLY);
+				g.fillRect(xOffset+(baseWidth*i), getY(20), baseWidth, getY(yStart)-getY(20));
+
+				g.setColor(CB_BAD);
+				g.fillRect(xOffset+(baseWidth*i), getY(28), baseWidth, getY(20)-getY(28));
+
+				g.setColor(CB_GOOD);
+				g.fillRect(xOffset+(baseWidth*i), getY(maxY), baseWidth, getY(28)-getY(maxY));
+
+				g.setColor(Color.LIGHT_GRAY);
+				g.drawLine(xOffset+(baseWidth*i),getY(0), xOffset+(baseWidth*i),getY(maxY));
+
+				g.setColor(Color.BLACK);
+				int baseNumberWidth = g.getFontMetrics().stringWidth(xLabels[i]);
+				int labelStart = ((baseWidth/2)+xOffset+(baseWidth*i))-(baseNumberWidth/2);
+				
+				if (labelStart > lastXLabelEnd) {
+					g.drawString(xLabels[i], labelStart, getHeight()-25);
+					lastXLabelEnd = labelStart+g.getFontMetrics().stringWidth(xLabels[i])+5;
+				}
 			}
-			else {
-				g.setColor(BAD_DARK);
-			}
+		} else {
+			for (int i=0;i<means.length;i++) {		// Now draw some background colours which show good / bad quality
+				if (i%2 != 0) {
+					g.setColor(UGLY);
+				}
+				else {
+					g.setColor(UGLY_DARK);
+				}
 
-			g.fillRect(xOffset+(baseWidth*i), getY(28), baseWidth, getY(20)-getY(28));
+				g.fillRect(xOffset+(baseWidth*i), getY(20), baseWidth, getY(yStart)-getY(20));
 
-			if (i%2 != 0) {
-				g.setColor(GOOD);
-			}
-			else {
-				g.setColor(GOOD_DARK);
-			}
+				if (i%2 != 0) {
+					g.setColor(BAD);
+				}
+				else {
+					g.setColor(BAD_DARK);
+				}
 
-			g.fillRect(xOffset+(baseWidth*i), getY(maxY), baseWidth, getY(28)-getY(maxY));
+				g.fillRect(xOffset+(baseWidth*i), getY(28), baseWidth, getY(20)-getY(28));
 
-			g.setColor(Color.BLACK);
-			int baseNumberWidth = g.getFontMetrics().stringWidth(xLabels[i]);
-			int labelStart = ((baseWidth/2)+xOffset+(baseWidth*i))-(baseNumberWidth/2);
-			
-			if (labelStart > lastXLabelEnd) {
-				g.drawString(xLabels[i], labelStart, getHeight()-25);
-				lastXLabelEnd = labelStart+g.getFontMetrics().stringWidth(xLabels[i])+5;
+				if (i%2 != 0) {
+					g.setColor(GOOD);
+				}
+				else {
+					g.setColor(GOOD_DARK);
+				}
+
+				g.fillRect(xOffset+(baseWidth*i), getY(maxY), baseWidth, getY(28)-getY(maxY));
+
+				g.setColor(Color.BLACK);
+				int baseNumberWidth = g.getFontMetrics().stringWidth(xLabels[i]);
+				int labelStart = ((baseWidth/2)+xOffset+(baseWidth*i))-(baseNumberWidth/2);
+				
+				if (labelStart > lastXLabelEnd) {
+					g.drawString(xLabels[i], labelStart, getHeight()-25);
+					lastXLabelEnd = labelStart+g.getFontMetrics().stringWidth(xLabels[i])+5;
+				}
 			}
 		}
-		
 		// Now draw the axes
 		g.drawLine(xOffset, getHeight()-40, getWidth()-10,getHeight()-40);
 		g.drawLine(xOffset, getHeight()-40, xOffset, 40);
@@ -172,7 +203,11 @@ public class QualityBoxPlot extends JPanel {
 //			System.out.println("For base "+i+" Yvalues are BoxBottom="+boxBottomY+" boxTop="+boxTopY+" whiskerBottom="+lowerWhiskerY+" whiskerTop="+upperWhiskerY+" median="+medianY);
 			
 			// Draw the main box
-			g.setColor(new Color(240,240,0));
+			if (System.getProperty("fastqc.colourblind")!=null && System.getProperty("fastqc.colourblind").equals("true")) { 
+				g.setColor(new Color(187,204,238));
+			} else {
+				g.setColor(new Color(240,240,0));
+			}
 			g.fillRect(xOffset+(baseWidth*i)+2, boxTopY, baseWidth-4, boxBottomY-boxTopY);
 			g.setColor(Color.BLACK);
 			g.drawRect(xOffset+(baseWidth*i)+2, boxTopY, baseWidth-4, boxBottomY-boxTopY);
@@ -186,14 +221,22 @@ public class QualityBoxPlot extends JPanel {
 			g.drawLine(xOffset+(baseWidth*i)+2, lowerWhiskerY, xOffset+(baseWidth*(i+1))-2, lowerWhiskerY);
 
 			// Draw the median line
-			g.setColor(new Color(200,0,0));
+			if (System.getProperty("fastqc.colourblind")!=null && System.getProperty("fastqc.colourblind").equals("true")) { 
+				g.setColor(new Color(34,85,34));
+			} else {
+				g.setColor(new Color(200,0,0));
+			}
 			g.drawLine(xOffset+(baseWidth*i)+2, medianY, (xOffset+(baseWidth*(i+1)))-2,medianY);
 
 			
 		}
 
 		// Now overlay the means
-		g.setColor(new Color(0,0,200));
+		if (System.getProperty("fastqc.colourblind")!=null && System.getProperty("fastqc.colourblind").equals("true")) { 
+			g.setColor(new Color(34,34,85));
+		} else {
+			g.setColor(new Color(0,0,200));
+		}
 		lastY = getY(means[0]);
 		for (int i=1;i<means.length;i++) {
 			int thisY = getY(means[i]);


### PR DESCRIPTION
Hi Simon,

We use fastqc as part of both our UG and PG teaching, and I'm trying to improve accessibilty to the tools we use, and the combination of red and green in some of the fastqc plot is a bit problematic.

This PR makes uses of a colourblind-friendly colour schemes (from https://personal.sron.nl/~pault/#sec:qualitative) when generating linegraph or qualitybox plots. Colourblind palettes tend to be a bit garish to the unaffected eye, so I've tried to select colours that don't look too horrific, and the default behaviour is unchanged. The cb-friendly palettes are only used when the `--colourblind` argument is provided on the command line. 

I've not done anything to the tile plots since the cb-friendly palettes are more limited in available colours, and I don't think there is such a problem there compared to the red/green combinations in the line plots.

Hopefully you will be happy to include these changes in the main fastqc codebase.