### PR TITLE
Update fastqc runner

### DIFF
--- a/fastqc
+++ b/fastqc
@@ -346,13 +346,8 @@ if (@files or $version or $help) {
 
 #warn "Running 'exec $java_bin,@java_args, \"uk.ac.babraham.FastQC.FastQCApplication\", @files, CLASSPATH is $ENV{CLASSPATH}";
 
-
-if ($java_bin ne 'java') {
-	system $java_bin,@java_args, "uk.ac.babraham.FastQC.FastQCApplication", @files;
-}
-else {
-	exec $java_bin,@java_args, "uk.ac.babraham.FastQC.FastQCApplication", @files;
-}
+system $java_bin,@java_args, "uk.ac.babraham.FastQC.FastQCApplication", @files;
+exit $? >> 8;
 
 __DATA__
 

--- a/fastqc
+++ b/fastqc
@@ -218,7 +218,7 @@ if ($threads) {
 	unshift @java_args,"-Xmx${used_memory}m";
 }
 else {
-	unshift @java_args,'-Xmx${memory}m';
+	unshift @java_args,"-Xmx${memory}m";
 }
 
 if ($kmer_size) {


### PR DESCRIPTION
Fix string interpolation by switching to double quotes.
Also switched to `system` only as the spawner for the Java application.