### PR TITLE
Add htsjdk to build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,6 +14,7 @@
         <pathelement location="jbzip2-0.9.jar"/>
         <pathelement location="sam-1.103.jar"/>
         <pathelement location="cisd-jhdf5.jar"/>
+        <pathelement location="htsjdk.jar"/>
     </path>
     <target name="init">
         <mkdir dir="bin"/>


### PR DESCRIPTION
Hi! Currently the build using ant is broken, because the htsjdk.jar is not included in the buildpath. 
This PR just add's it, as it's already present in this repository.