### PR TITLE
Add FindBin Perl module install guide for Linux

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -82,6 +82,10 @@ chmod 755 fastqc
 
 sudo ln -s /path/to/FastQC/fastqc /usr/local/bin/fastqc
 
+If you can't run the fastqc due to a missing FinBin Perl module, you can install the FinBin module using the command below:
+For Fedora and similar distros (uses dnf or rpm): sudo dnf install perl-FindBin
+For Ubuntu and similar distros (uses apt): sudo apt-get install libfindbin-libs-perl
+For other distros, please refer to guides on how to install FinBin Perl module.
 
 Running FastQC as part of a pipeline
 ------------------------------------


### PR DESCRIPTION
When installing FastQC on Fedora, the fastqc can't run due to a missing FindBin Perl module. To solve this, it more more appropriate to add a guide on how to install the FindBin module and run the fastqc command smoothly on Linux.