### PR TITLE
Optimise SVG plots, bump SVG line widths

### DIFF
--- a/uk/ac/babraham/FastQC/Utilities/ImageSaver/SVGGenerator.java
+++ b/uk/ac/babraham/FastQC/Utilities/ImageSaver/SVGGenerator.java
@@ -134,6 +134,7 @@ public class SVGGenerator {
 		sb.append("\" height=\"");
 		sb.append(c.getHeight());
 		sb.append("\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n");
+		sb.append("<style>text{font-family:Arial}</style>\n");
 
 		c.paint(new SVGGraphics());
 
@@ -237,7 +238,7 @@ public class SVGGenerator {
 			sb.append(y2);
 			sb.append("\" stroke=\"rgb(");
 			appendColor();
-			sb.append(")\" stroke-width=\"1\"/>\n");
+			sb.append(")\" stroke-width=\"2\"/>\n");
 		}
 	
 		/* (non-Javadoc)
@@ -273,9 +274,9 @@ public class SVGGenerator {
 			sb.append(width);
 			sb.append("\" ry=\"");
 			sb.append(height);
-			sb.append("\" style=\"fill:none;stroke:rgb(");
+			sb.append("\" fill=\"none\" stroke=\"rgb(");
 			appendColor();
-			sb.append(");stroke-width:1\"/>\n");
+			sb.append(")\"/>\n");
 		}
 		
 		/* (non-Javadoc)
@@ -311,9 +312,9 @@ public class SVGGenerator {
 			sb.append(width);
 			sb.append("\" ry=\"");
 			sb.append(height);
-			sb.append("\" style=\"fill:rgb(");
+			sb.append("\" fill=\"rgb(");
 			appendColor();
-			sb.append(");stroke:none\"/>\n");
+			sb.append(")\"/>\n");
 		}
 	
 		/* (non-Javadoc)
@@ -344,7 +345,7 @@ public class SVGGenerator {
 			sb.append(y);
 			sb.append("\" fill=\"rgb(");
 			appendColor();
-			sb.append(")\" font-family=\"Arial\" font-size=\"");
+			sb.append(")\" font-size=\"");
 			sb.append(font.getSize());
 			if (font.isBold()) {
 				sb.append("\" font-weight=\"bold");
@@ -404,8 +405,7 @@ public class SVGGenerator {
 			sb.append(arcWidth);
 			sb.append("\" ry=\"");
 			sb.append(arcHeight);
-			sb.append("\" style=\"fill:none");
-			sb.append(";stroke-width:1;stroke:rgb(");
+			sb.append("\" fill=\"none\" stroke=\"rgb(");
 					
 			appendColor();
 					
@@ -450,11 +450,11 @@ public class SVGGenerator {
 				sb.append("\" ry=\"");
 				sb.append(arcHeight);
 			}
-			sb.append("\" style=\"fill:rgb(");
+			sb.append("\" fill=\"rgb(");
 			
 			appendColor();
 	
-			sb.append(");stroke:none\"/>\n");
+			sb.append(")\"/>\n");
 		}
 		
 		/* (non-Javadoc)
@@ -607,11 +607,11 @@ public class SVGGenerator {
 				sb.append(correctedYPoints[i]);
 			}
 			
-			sb.append("\" style=\"stroke-width:1;stroke:rgb(");
+			sb.append("\" fill=\"none\" stroke=\"rgb(");
 			
 			appendColor();
 	
-			sb.append(");fill:none\"/>\n");
+			sb.append(")\"/>\n");
 		}
 	
 		/* (non-Javadoc)
@@ -661,11 +661,11 @@ public class SVGGenerator {
 				sb.append(correctedYPoints[i]);
 			}
 			
-			sb.append("\" style=\"fill:rgb(");
+			sb.append("\" fill=\"rgb(");
 			
 			appendColor();
 	
-			sb.append(");stroke:none\"/>\n");
+			sb.append(")\"/>\n");
 
 		}
 	

--- a/uk/ac/babraham/FastQC/Utilities/ImageSaver/SVGImageSaver.java
+++ b/uk/ac/babraham/FastQC/Utilities/ImageSaver/SVGImageSaver.java
@@ -22,6 +22,9 @@ package uk.ac.babraham.FastQC.Utilities.ImageSaver;
 import java.awt.Component;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**
@@ -31,14 +34,135 @@ import java.io.PrintWriter;
  */
 public class SVGImageSaver {
 
+	private static final Pattern LINE_PATTERN = Pattern.compile(
+		"<line x1=\"(\\d+)\" y1=\"(\\d+)\" x2=\"(\\d+)\" y2=\"(\\d+)\" stroke=\"(rgb\\([^)]+\\))\" stroke-width=\"(\\d+)\"/>"
+	);
+
+	private static final Pattern RECT_PATTERN = Pattern.compile(
+		"<rect width=\"(\\d+)\" height=\"(\\d+)\" x=\"(\\d+)\" y=\"(\\d+)\" fill=\"(rgb\\([^)]+\\))\"/>"
+	);
+
 	public static String saveImage (Component c, OutputStream os) {
 		PrintWriter pr = new PrintWriter(os);
 		String svgData = SVGGenerator.writeSVG(c);
+		svgData = optimizeSvg(svgData);
 		pr.write(svgData);
 		pr.flush();
 		return(svgData);
 	}
-	
-	
-			
+
+	private static String optimizeSvg(String svg) {
+		svg = mergeLinesToPolylines(svg);
+		svg = mergeRects(svg);
+		return svg;
+	}
+
+	/** Merge consecutive same-colour line elements into polyline elements. */
+	private static String mergeLinesToPolylines(String svg) {
+		String[] lines = svg.split("\n");
+		StringBuilder result = new StringBuilder(svg.length());
+		ArrayList<String[]> group = new ArrayList<>();
+		String groupStroke = null;
+		String groupWidth = null;
+
+		for (String line : lines) {
+			Matcher m = LINE_PATTERN.matcher(line.trim());
+			if (m.matches()) {
+				String stroke = m.group(5);
+				String width = m.group(6);
+				if ("rgb(0,0,0)".equals(stroke) || "rgb(180,180,180)".equals(stroke)) {
+					flushLineGroup(result, group, groupStroke, groupWidth);
+					group.clear();
+					groupStroke = null;
+					result.append(line).append("\n");
+				} else if (stroke.equals(groupStroke) && width.equals(groupWidth)) {
+					group.add(new String[]{m.group(1), m.group(2), m.group(3), m.group(4)});
+				} else {
+					flushLineGroup(result, group, groupStroke, groupWidth);
+					group.clear();
+					groupStroke = stroke;
+					groupWidth = width;
+					group.add(new String[]{m.group(1), m.group(2), m.group(3), m.group(4)});
+				}
+			} else {
+				flushLineGroup(result, group, groupStroke, groupWidth);
+				group.clear();
+				groupStroke = null;
+				result.append(line).append("\n");
+			}
+		}
+		flushLineGroup(result, group, groupStroke, groupWidth);
+		return result.toString();
+	}
+
+	private static void flushLineGroup(StringBuilder sb, ArrayList<String[]> group, String stroke, String width) {
+		if (group.size() <= 2) {
+			for (String[] seg : group) {
+				sb.append("<line x1=\"").append(seg[0]).append("\" y1=\"").append(seg[1])
+				  .append("\" x2=\"").append(seg[2]).append("\" y2=\"").append(seg[3])
+				  .append("\" stroke=\"").append(stroke).append("\" stroke-width=\"").append(width)
+				  .append("\"/>\n");
+			}
+			return;
+		}
+		StringBuilder points = new StringBuilder();
+		points.append(group.get(0)[0]).append(",").append(group.get(0)[1]);
+		for (String[] seg : group) {
+			points.append(" ").append(seg[2]).append(",").append(seg[3]);
+		}
+		sb.append("<polyline points=\"").append(points)
+		  .append("\" stroke=\"").append(stroke).append("\" stroke-width=\"").append(width)
+		  .append("\" fill=\"none\"/>\n");
+	}
+
+	/** Merge consecutive same-colour filled rects on the same row into wider rects. */
+	private static String mergeRects(String svg) {
+		String[] lines = svg.split("\n");
+		StringBuilder result = new StringBuilder(svg.length());
+		ArrayList<int[]> group = new ArrayList<>();
+		String groupFill = null;
+
+		for (String line : lines) {
+			Matcher m = RECT_PATTERN.matcher(line.trim());
+			if (m.matches()) {
+				int w = Integer.parseInt(m.group(1));
+				int h = Integer.parseInt(m.group(2));
+				int x = Integer.parseInt(m.group(3));
+				int y = Integer.parseInt(m.group(4));
+				String fill = m.group(5);
+				if (w > 100 || h > 100) {
+					flushRectGroup(result, group, groupFill);
+					group.clear();
+					groupFill = null;
+					result.append(line).append("\n");
+				} else if (fill.equals(groupFill) && !group.isEmpty()
+						&& y == group.get(0)[3] && h == group.get(0)[1]
+						&& x == group.get(0)[2] + group.get(0)[0] * group.size()) {
+					group.add(new int[]{w, h, x, y});
+				} else {
+					flushRectGroup(result, group, groupFill);
+					group.clear();
+					groupFill = fill;
+					group.add(new int[]{w, h, x, y});
+				}
+			} else {
+				flushRectGroup(result, group, groupFill);
+				group.clear();
+				groupFill = null;
+				result.append(line).append("\n");
+			}
+		}
+		flushRectGroup(result, group, groupFill);
+		return result.toString();
+	}
+
+	private static void flushRectGroup(StringBuilder sb, ArrayList<int[]> group, String fill) {
+		if (group.isEmpty()) return;
+		int mergedWidth = group.get(0)[0] * group.size();
+		int[] first = group.get(0);
+		sb.append("<rect width=\"").append(mergedWidth).append("\" height=\"").append(first[1])
+		  .append("\" x=\"").append(first[2]).append("\" y=\"").append(first[3])
+		  .append("\" fill=\"").append(fill).append("\"/>\n");
+	}
+
 }


### PR DESCRIPTION
Optimised the SVG plot outputs, reducing total SVG file size by 73% with no visual changes.

This is fairly meaningless by itself, but in the future I would love for the HTML reports to embed SVGs instead of PNGs. Then the file size of the SVGs suddenly does matter, as they're all embedded and we don't want massive HTML files.

The main improvement is for per-tile sequence quality, but there are improvements on all SVGs. Example on a 27M-read FASTQ file (ERR16944282):

| SVG file | Before | After | Reduction |
|---|---|---|---|
| `adapter_content.svg` | 40.1 KB | 10.1 KB | 75% |
| `duplication_levels.svg` | 6.2 KB | 4.4 KB | 29% |
| `per_base_n_content.svg` | 13.2 KB | 7.0 KB | 47% |
| `per_base_quality.svg` | 67.1 KB | 55.3 KB | 17% |
| `per_base_sequence_content.svg` | 30.4 KB | 9.0 KB | 70% |
| `per_sequence_gc_content.svg` | 25.6 KB | 9.0 KB | 65% |
| `per_sequence_quality.svg` | 8.8 KB | 5.3 KB | 40% |
| `per_tile_quality.svg` | 395.7 KB 👈🏻  | 58.4 KB | 85% |
| `sequence_length_distribution.svg` | 3.1 KB | 2.8 KB | 11% |
| **Total** | **590.2 KB** | **161.4 KB** | **73%** |

<details><summary>Changes 🤖 </summary>

AI summary of changes:

### Shorter attributes (`SVGGenerator.java`)

- Move `font-family="Arial"` from every `<text>` element to a single `<style>` block in the SVG header
- Replace verbose `style="fill:rgb(...);stroke:none"` with `fill="rgb(...)"`
- Replace `style="fill:none;stroke-width:1;stroke:rgb(...)"` with `fill="none" stroke="rgb(...)"`
- Same for polygons and ellipses

### Element merging (`SVGImageSaver.java`)

Post-processing applied to the SVG string before writing to disk:

- **Line → polyline**: consecutive same-colour `<line>` segments (data series) are merged into a single `<polyline>` with `stroke-width="2"` for better visibility. Gridlines and axis lines (black/grey) are left as individual `<line>` elements with `stroke-width="1"`.
- **Rect run-length encoding**: consecutive same-colour `<rect>` elements on the same row are merged into a single wider rect. This primarily benefits the per-tile quality heatmap, which draws thousands of small rectangles.

### What's not affected

- **PNG rendering** is completely unchanged. PNGs are rendered via Java2D `Graphics2D`, which doesn't go through `SVGGenerator`
- **Text output** (`fastqc_data.txt`, `summary.txt`) is unchanged
- **HTML report** structure is unchanged (it embeds PNGs, not SVGs)

</details>

The only visual change is the thicker lines for line plots, which matches what the PNGs look like:

| Before optimisation | After optimisation |
| -- | -- |
| <img width="1020" height="600" alt="per_base_quality" src="https://github.com/user-attachments/assets/af2f0d6f-5f1f-4df8-9af4-6f5679937b59" /><br><code>69 KB</code> | <img width="1020" height="600" alt="per_base_quality" src="https://github.com/user-attachments/assets/131e47e4-ae52-496a-ba67-079717aaa42b" /><br><code>57 KB</code> |
| <img width="1020" height="600" alt="per_base_sequence_content" src="https://github.com/user-attachments/assets/81b432d1-93be-4e8f-a337-74a8d55d297a" /><br><code>31 KB</code> | <img width="1020" height="600" alt="per_base_sequence_content" src="https://github.com/user-attachments/assets/f25ea4a4-6a77-481f-8e02-0a217e1df7d4" /><br><code>9 KB</code> |
| <img width="1020" height="600" alt="per_tile_quality" src="https://github.com/user-attachments/assets/aa6b2fad-4c12-4f7d-bfcc-447328c06709" /><br><code>405 KB</code> | <img width="1020" height="600" alt="per_tile_quality" src="https://github.com/user-attachments/assets/5b6fdc78-7134-4036-a90d-f72cbb04e9ad" /><br><code>60 KB</code> |









