### PR TITLE
Fix dup_length handling for short reads

### DIFF
--- a/test/integration/DupLengthTest.java
+++ b/test/integration/DupLengthTest.java
@@ -1,0 +1,28 @@
+package test.integration;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import test.integration.cli.Cli;
+import test.integration.cli.CliScenario;
+
+public class DupLengthTest {
+
+    @Test
+    public void succeeds_when_dup_length_is_longer_than_reads() throws Exception {
+        Path outputDir = new File(CliScenario.TEST_OUT_DIR).toPath();
+        if (!Files.exists(outputDir)) {
+            Files.createDirectories(outputDir);
+        }
+
+        CliScenario scenario = new CliScenario("minimal", new String[] {
+                "fastqc.output_dir=" + outputDir,
+                "fastqc.dup_length=20"
+        });
+
+        Cli.Execute(scenario).assertSuccess();
+    }
+}

--- a/uk/ac/babraham/FastQC/Modules/OverRepresentedSeqs.java
+++ b/uk/ac/babraham/FastQC/Modules/OverRepresentedSeqs.java
@@ -159,7 +159,8 @@ public class OverRepresentedSeqs extends AbstractQCModule {
 		// dup_length option.
 		
 		if (FastQCConfig.getInstance().dupLength != 0) {
-			seq = new String(seq.substring(0, FastQCConfig.getInstance().dupLength));			
+			int dupLength = Math.min(FastQCConfig.getInstance().dupLength, seq.length());
+			seq = new String(seq.substring(0, dupLength));
 		}
 		else if (seq.length() > 50) {
 			seq = new String(seq.substring(0, 50));


### PR DESCRIPTION
Fixes #145.

When `fastqc.dup_length` / `--dup_length` is longer than a read, the overrepresented sequence module currently calls `substring(0, dupLength)` and crashes with `StringIndexOutOfBoundsException`.

This change caps the duplication truncation length at the actual sequence length, so short reads are kept whole instead of failing.

Also adds an integration regression test using the existing 16bp `minimal.fastq` fixture with `fastqc.dup_length=20`.

Validation:
- Reproduced the original crash with `fastqc.dup_length=20` against `test/data/minimal.fastq` before the fix.
- Compiled the touched production class and new regression test with Java 11.
- Ran `DupLengthTest`: 1 test found, 1 succeeded, 0 failed.
- Ran unit test package through JUnit launcher: 8 tests found, 8 succeeded, 0 failed.
- Ran `git diff --check`.