### PR TITLE
Enable text anti-aliasing to fix Liberation Sans rendering

### DIFF
--- a/uk/ac/babraham/FastQC/Dialogs/FastQCTitlePanel.java
+++ b/uk/ac/babraham/FastQC/Dialogs/FastQCTitlePanel.java
@@ -203,6 +203,7 @@ public class FastQCTitlePanel extends JPanel {
 			if (g instanceof Graphics2D) {
 				((Graphics2D)g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 			}
+			FontManager.enableTextAntialiasing(g);
 			super.paintComponent(g);
 		}
 

--- a/uk/ac/babraham/FastQC/FastQCApplication.java
+++ b/uk/ac/babraham/FastQC/FastQCApplication.java
@@ -292,7 +292,13 @@ public class FastQCApplication extends JFrame {
 	}
 
 	public static void main(String[] args) {
-		
+
+		// Enable system-wide font anti-aliasing for Swing. Must be set before
+		// any AWT/Swing class loads. Liberation Sans renders poorly on
+		// Windows/Linux without this; see GitHub issue #193.
+		System.setProperty("awt.useSystemAAFontSettings", "on");
+		System.setProperty("swing.aatext", "true");
+
 		// See if we just have to print out the version
 		if (System.getProperty("fastqc.show_version") != null && System.getProperty("fastqc.show_version").equals("true")) {
 			System.out.println("FastQC v"+VERSION);

--- a/uk/ac/babraham/FastQC/Graphs/LineGraph.java
+++ b/uk/ac/babraham/FastQC/Graphs/LineGraph.java
@@ -108,6 +108,8 @@ public class LineGraph extends JPanel {
 	public void paint (Graphics g) {
 		super.paint(g);
 
+		FontManager.enableTextAntialiasing(g);
+
 		g.setFont(FontManager.defaultFont());
 		g.setColor(Color.WHITE);
 		g.fillRect(0, 0, getWidth(), getHeight());

--- a/uk/ac/babraham/FastQC/Graphs/QualityBoxPlot.java
+++ b/uk/ac/babraham/FastQC/Graphs/QualityBoxPlot.java
@@ -67,6 +67,8 @@ public class QualityBoxPlot extends JPanel {
 	public void paint (Graphics g) {
 		super.paint(g);
 
+		FontManager.enableTextAntialiasing(g);
+
 		g.setFont(FontManager.defaultFont());
 		g.setColor(Color.WHITE);
 		g.fillRect(0, 0, getWidth(), getHeight());

--- a/uk/ac/babraham/FastQC/Graphs/TileGraph.java
+++ b/uk/ac/babraham/FastQC/Graphs/TileGraph.java
@@ -55,6 +55,8 @@ public class TileGraph extends JPanel {
 	public void paint (Graphics g) {
 		super.paint(g);
 
+		FontManager.enableTextAntialiasing(g);
+
 		g.setFont(FontManager.defaultFont());
 		g.setColor(Color.WHITE);
 		g.fillRect(0, 0, getWidth(), getHeight());

--- a/uk/ac/babraham/FastQC/Help/HelpPageDisplay.java
+++ b/uk/ac/babraham/FastQC/Help/HelpPageDisplay.java
@@ -34,6 +34,8 @@ import javax.swing.JScrollPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 
+import uk.ac.babraham.FastQC.Utilities.FontManager;
+
 /**
  * The Class HelpPageDisplay.
  */
@@ -92,7 +94,8 @@ public class HelpPageDisplay extends JPanel implements HyperlinkListener {
 			if (g instanceof Graphics2D) {
 				Graphics2D g2 = (Graphics2D)g;
 				g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,RenderingHints.VALUE_ANTIALIAS_ON);
-			}	
+			}
+			FontManager.enableTextAntialiasing(g);
 			super.paint(g);
 		}
 	}

--- a/uk/ac/babraham/FastQC/Utilities/FontManager.java
+++ b/uk/ac/babraham/FastQC/Utilities/FontManager.java
@@ -21,7 +21,10 @@ package uk.ac.babraham.FastQC.Utilities;
 
 import java.awt.Font;
 import java.awt.FontFormatException;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -96,5 +99,19 @@ public class FontManager {
 	public static Font defaultBoldFont() {
 		initialize();
 		return cachedDefaultBoldFont;
+	}
+
+	/**
+	 * Enable text anti-aliasing on the given Graphics context. Liberation Sans
+	 * has weaker bytecode hinting than Microsoft's Arial, so without text AA the
+	 * font looks jagged on Windows/Linux at small sizes. macOS enables text AA
+	 * by default via CoreText, so this is a no-op there in practice.
+	 */
+	public static void enableTextAntialiasing(Graphics g) {
+		if (g instanceof Graphics2D) {
+			Graphics2D g2 = (Graphics2D) g;
+			g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+			g2.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #193. Liberation Sans has weaker bytecode hinting than Microsoft's Arial, so without explicit text anti-aliasing it renders jagged on Windows/Linux at small font sizes. macOS was fine because CoreText anti-aliases text by default.

This sets `awt.useSystemAAFontSettings` and `swing.aatext` at app startup for normal Swing components, and adds a `FontManager.enableTextAntialiasing` helper invoked from each custom `paint()` method (graphs, title panel, help page) to cover `Graphics2D` paths and the PNG export route via `print(g)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)