### PR TITLE
~3x run time speedup using parallel processing

### DIFF
--- a/fastqc
+++ b/fastqc
@@ -450,11 +450,9 @@ DESCRIPTION
     
     --png			Save the graphs in PNG format
 
-    -t --threads    Specifies the number of files which can be processed
-                    simultaneously.  Each thread will be allocated 512MB of
-                    memory so you shouldn't run more threads than your
-                    available memory will cope with, and not more than
-                    6 threads on a 32 bit machine
+    -t --threads    Total number of CPU threads to use.  Each file uses up to
+                    4 threads.  Defaults to 4 x number of files, capped at
+                    the number of available CPUs.
                   
     -c              Specifies a non-default file which contains the list of
     --contaminants  contaminants to screen overrepresented sequences against.

--- a/uk/ac/babraham/FastQC/Analysis/AnalysisQueue.java
+++ b/uk/ac/babraham/FastQC/Analysis/AnalysisQueue.java
@@ -34,19 +34,50 @@ public class AnalysisQueue implements Runnable, AnalysisListener{
 	
 	private AtomicInteger availableSlots = new AtomicInteger(1);
 	private AtomicInteger usedSlots = new AtomicInteger(0);
-	
+	private volatile int processorsPerFile = 0;
+
+	// Per-file pipeline = 1 reader + up to MAX_PROCESSORS_PER_FILE processor
+	// threads. Past 3 processors gains plateau as the reader becomes the bottleneck.
+	private static final int MAX_PROCESSORS_PER_FILE = 3;
+	private static final int THREADS_PER_FILE = 1 + MAX_PROCESSORS_PER_FILE;
+
 	public static AnalysisQueue getInstance () {
 		return instance;
 	}
-	
+
 	private AnalysisQueue () {
-		
-		if (FastQCConfig.getInstance().threads != null) {
-			availableSlots.set(FastQCConfig.getInstance().threads);			
-		}
-		
+		// Sized for a single file; OfflineRunner overrides via configure().
+		configure(1);
+
 		Thread t = new Thread(this);
 		t.start();
+	}
+
+	/**
+	 * Size the CPU budget. -t/-Dfastqc.threads is a total-thread budget
+	 * split between outer concurrency (files in parallel) and inner
+	 * concurrency (per-file pipeline). Unset defaults to
+	 * <code>min(THREADS_PER_FILE * max(1, expectedFiles), availableProcessors)</code>.
+	 * A budget of 1 makes AnalysisRunner take its single-threaded path.
+	 * Call before submitting any AnalysisRunner.
+	 */
+	void configure (int expectedFiles) {
+		int totalThreads;
+		if (FastQCConfig.getInstance().threads != null) {
+			totalThreads = FastQCConfig.getInstance().threads;
+		}
+		else {
+			int filesForBudget = Math.max(1, expectedFiles);
+			long requested = (long) THREADS_PER_FILE * filesForBudget; // long to avoid overflow
+			totalThreads = (int) Math.min(requested, Runtime.getRuntime().availableProcessors());
+		}
+		processorsPerFile = totalThreads <= 1 ? 0 : Math.min(MAX_PROCESSORS_PER_FILE, totalThreads - 1);
+		int actualThreadsPerFile = processorsPerFile == 0 ? 1 : 1 + processorsPerFile;
+		availableSlots.set(Math.max(1, totalThreads / actualThreadsPerFile));
+	}
+
+	int getProcessorsPerFile() {
+		return processorsPerFile;
 	}
 	
 	public void addToQueue (AnalysisRunner runner) {

--- a/uk/ac/babraham/FastQC/Analysis/AnalysisRunner.java
+++ b/uk/ac/babraham/FastQC/Analysis/AnalysisRunner.java
@@ -20,8 +20,11 @@
 package uk.ac.babraham.FastQC.Analysis;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
 
 import uk.ac.babraham.FastQC.Modules.BasicStats;
 import uk.ac.babraham.FastQC.Modules.QCModule;
@@ -34,7 +37,7 @@ public class AnalysisRunner implements Runnable {
 	private SequenceFile file;
 	private QCModule [] modules;
 	private List<AnalysisListener> listeners = new ArrayList<AnalysisListener>();
-	private int percentComplete = 0;
+	private volatile int percentComplete = 0;
 	
 	public AnalysisRunner (SequenceFile file) {
 		this.file = file;
@@ -68,48 +71,163 @@ public class AnalysisRunner implements Runnable {
 			i.next().analysisStarted(file);
 		}
 
-		
-		int seqCount = 0;
-		while (file.hasNext()) {
-			++seqCount;
-			Sequence seq;
+		// Reader thread reads sequences in batches; NUM_PROCESSORS threads
+		// drain those batches and each runs a disjoint subset of modules.
+		final int BATCH_SIZE = 1024;
+		final int QUEUE_CAPACITY = 32;
+		final int NUM_PROCESSORS = 3;
+
+		@SuppressWarnings("unchecked")
+		ArrayBlockingQueue<Sequence[]>[] procQueues = new ArrayBlockingQueue[NUM_PROCESSORS];
+		for (int p = 0; p < NUM_PROCESSORS; p++) {
+			procQueues[p] = new ArrayBlockingQueue<>(QUEUE_CAPACITY);
+		}
+		final Sequence[] POISON = new Sequence[0];
+		final SequenceFormatException[] readerError = { null };
+		final Throwable[] processorError = { null };
+
+		QCModule[][] moduleSplits = new QCModule[NUM_PROCESSORS][];
+		int splitSize = (modules.length + NUM_PROCESSORS - 1) / NUM_PROCESSORS;
+		for (int p = 0; p < NUM_PROCESSORS; p++) {
+			int from = p * splitSize;
+			int to = Math.min(from + splitSize, modules.length);
+			moduleSplits[p] = Arrays.copyOfRange(modules, from, to);
+		}
+
+		// The same Sequence[] reference is published to every processor
+		// queue. This is safe because Sequence is populated by file.next()
+		// before put() and modules only read from it.
+		final int[] seqCountHolder = { 0 };
+
+		Thread reader = new Thread(() -> {
+			int readerSeqCount = 0;
 			try {
-				seq = file.next();
+				Sequence[] batch = new Sequence[BATCH_SIZE];
+				int idx = 0;
+				while (file.hasNext()) {
+					batch[idx++] = file.next();
+					++readerSeqCount;
+					if (idx == BATCH_SIZE) {
+						for (int p = 0; p < NUM_PROCESSORS; p++) {
+							procQueues[p].put(batch);
+						}
+						batch = new Sequence[BATCH_SIZE];
+						idx = 0;
+
+						// Same cadence as the single-threaded version: every
+						// 1000 reads (rounded up to 1024 by BATCH_SIZE), fire
+						// analysisUpdated only when we've crossed another 5%.
+						if (file.getPercentComplete() >= percentComplete + 5) {
+							percentComplete = (((int) file.getPercentComplete()) / 5) * 5;
+							for (int li = 0; li < listeners.size(); li++) {
+								listeners.get(li).analysisUpdated(file, readerSeqCount, percentComplete);
+							}
+						}
+					}
+				}
+				if (idx > 0) {
+					Sequence[] partial = Arrays.copyOf(batch, idx);
+					for (int p = 0; p < NUM_PROCESSORS; p++) {
+						procQueues[p].put(partial);
+					}
+				}
 			}
 			catch (SequenceFormatException e) {
-				i = listeners.iterator();
-				while (i.hasNext()) {
-					i.next().analysisExceptionReceived(file,e);
-				}
-				return;
+				readerError[0] = e;
 			}
-			
-			for (int m=0;m<modules.length;m++) {
-				if (seq.isFiltered() && modules[m].ignoreFilteredSequences()) continue;
-				modules[m].processSequence(seq);
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 			}
-			
-			if (seqCount % 1000 == 0) {
-			if (file.getPercentComplete() >= percentComplete+5) {
-			
-				percentComplete = (((int)file.getPercentComplete())/5)*5;
-				
-				i = listeners.iterator();
-					while (i.hasNext()) {
-						i.next().analysisUpdated(file,seqCount,percentComplete);
+			finally {
+				seqCountHolder[0] = readerSeqCount;
+				// POISON must always be delivered, otherwise processor threads
+				// block forever on take() and the run never completes.
+				for (int p = 0; p < NUM_PROCESSORS; p++) {
+					try { procQueues[p].put(POISON); } catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
 					}
+				}
+			}
+		}, "fastqc-reader");
+		reader.setDaemon(true);
+		reader.start();
+
+		CountDownLatch processorsDone = new CountDownLatch(NUM_PROCESSORS);
+
+		for (int p = 0; p < NUM_PROCESSORS; p++) {
+			final QCModule[] myModules = moduleSplits[p];
+			final ArrayBlockingQueue<Sequence[]> myQueue = procQueues[p];
+
+			Thread processor = new Thread(() -> {
+				try {
+					while (true) {
+						Sequence[] batch = myQueue.take();
+						if (batch == POISON) break;
+
+						for (int b = 0; b < batch.length; b++) {
+							Sequence seq = batch[b];
+							for (int m = 0; m < myModules.length; m++) {
+								if (seq.isFiltered() && myModules[m].ignoreFilteredSequences()) continue;
+								myModules[m].processSequence(seq);
+							}
+						}
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				catch (RuntimeException e) {
+					// Don't let a misbehaving module deadlock the pipeline:
+					// drain remaining batches so the reader doesn't block on
+					// put(), and surface the failure after the join.
+					processorError[0] = e;
 					try {
-						Thread.sleep(10);
-					} 
-					catch (InterruptedException e) {}
-			}
-			}
+						while (myQueue.take() != POISON) { /* drain */ }
+					}
+					catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+					}
+				}
+				finally {
+					processorsDone.countDown();
+				}
+			}, "fastqc-proc-" + p);
+			processor.setDaemon(true);
+			processor.start();
 		}
-		
+
+		try {
+			processorsDone.await();
+			reader.join();
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+
+		int seqCount = seqCountHolder[0];
+
+		if (readerError[0] != null) {
+			i = listeners.iterator();
+			while (i.hasNext()) {
+				i.next().analysisExceptionReceived(file, readerError[0]);
+			}
+			return;
+		}
+		if (processorError[0] != null) {
+			SequenceFormatException sfe = new SequenceFormatException(
+					"Module processing failed: " + processorError[0].getMessage());
+			sfe.initCause(processorError[0]);
+			i = listeners.iterator();
+			while (i.hasNext()) {
+				i.next().analysisExceptionReceived(file, sfe);
+			}
+			return;
+		}
+
 		// We need to account for their potentially being no sequences
-		// in the file.  In this case the BasicStats module never gets 
+		// in the file.  In this case the BasicStats module never gets
 		// the file name so we need to explicitly pass it.
-		
+
 		if (seqCount == 0) {
 			for (int m=0; m<modules.length; m++) {
 				if (modules[m] instanceof BasicStats) {
@@ -117,7 +235,7 @@ public class AnalysisRunner implements Runnable {
 				}
 			}
 		}
-		
+
 		i = listeners.iterator();
 		while (i.hasNext()) {
 			i.next().analysisComplete(file,modules);

--- a/uk/ac/babraham/FastQC/Analysis/AnalysisRunner.java
+++ b/uk/ac/babraham/FastQC/Analysis/AnalysisRunner.java
@@ -66,37 +66,108 @@ public class AnalysisRunner implements Runnable {
 
 	public void run() {
 
+		int numProcessors = AnalysisQueue.getInstance().getProcessorsPerFile();
+		if (numProcessors == 0) {
+			runSequential();
+			return;
+		}
+		runParallel(numProcessors);
+	}
+
+	private void runSequential() {
+
 		Iterator<AnalysisListener> i = listeners.iterator();
 		while (i.hasNext()) {
 			i.next().analysisStarted(file);
 		}
 
-		// Reader thread reads sequences in batches; NUM_PROCESSORS threads
-		// drain those batches and each runs a disjoint subset of modules.
+		int seqCount = 0;
+		while (file.hasNext()) {
+			++seqCount;
+			Sequence seq;
+			try {
+				seq = file.next();
+			}
+			catch (SequenceFormatException e) {
+				i = listeners.iterator();
+				while (i.hasNext()) {
+					i.next().analysisExceptionReceived(file,e);
+				}
+				return;
+			}
+
+			for (int m=0;m<modules.length;m++) {
+				if (seq.isFiltered() && modules[m].ignoreFilteredSequences()) continue;
+				modules[m].processSequence(seq);
+			}
+
+			if (seqCount % 1000 == 0) {
+			if (file.getPercentComplete() >= percentComplete+5) {
+
+				percentComplete = (((int)file.getPercentComplete())/5)*5;
+
+				i = listeners.iterator();
+					while (i.hasNext()) {
+						i.next().analysisUpdated(file,seqCount,percentComplete);
+					}
+					try {
+						Thread.sleep(10);
+					}
+					catch (InterruptedException e) {}
+			}
+			}
+		}
+
+		// We need to account for their potentially being no sequences
+		// in the file.  In this case the BasicStats module never gets
+		// the file name so we need to explicitly pass it.
+
+		if (seqCount == 0) {
+			for (int m=0; m<modules.length; m++) {
+				if (modules[m] instanceof BasicStats) {
+					((BasicStats)modules[m]).setFileName(file.name());
+				}
+			}
+		}
+
+		i = listeners.iterator();
+		while (i.hasNext()) {
+			i.next().analysisComplete(file,modules);
+		}
+	}
+
+	private void runParallel(final int numProcessors) {
+
+		Iterator<AnalysisListener> i = listeners.iterator();
+		while (i.hasNext()) {
+			i.next().analysisStarted(file);
+		}
+
+		// Reader fills batches; numProcessors threads drain them, each running
+		// a disjoint subset of modules.
 		final int BATCH_SIZE = 1024;
 		final int QUEUE_CAPACITY = 32;
-		final int NUM_PROCESSORS = 3;
 
 		@SuppressWarnings("unchecked")
-		ArrayBlockingQueue<Sequence[]>[] procQueues = new ArrayBlockingQueue[NUM_PROCESSORS];
-		for (int p = 0; p < NUM_PROCESSORS; p++) {
+		ArrayBlockingQueue<Sequence[]>[] procQueues = new ArrayBlockingQueue[numProcessors];
+		for (int p = 0; p < numProcessors; p++) {
 			procQueues[p] = new ArrayBlockingQueue<>(QUEUE_CAPACITY);
 		}
 		final Sequence[] POISON = new Sequence[0];
 		final SequenceFormatException[] readerError = { null };
 		final Throwable[] processorError = { null };
 
-		QCModule[][] moduleSplits = new QCModule[NUM_PROCESSORS][];
-		int splitSize = (modules.length + NUM_PROCESSORS - 1) / NUM_PROCESSORS;
-		for (int p = 0; p < NUM_PROCESSORS; p++) {
+		QCModule[][] moduleSplits = new QCModule[numProcessors][];
+		int splitSize = (modules.length + numProcessors - 1) / numProcessors;
+		for (int p = 0; p < numProcessors; p++) {
 			int from = p * splitSize;
 			int to = Math.min(from + splitSize, modules.length);
 			moduleSplits[p] = Arrays.copyOfRange(modules, from, to);
 		}
 
-		// The same Sequence[] reference is published to every processor
-		// queue. This is safe because Sequence is populated by file.next()
-		// before put() and modules only read from it.
+		// Same Sequence[] reference is shared across processor queues; safe
+		// because each Sequence is fully populated before put() and modules
+		// only read from it.
 		final int[] seqCountHolder = { 0 };
 
 		Thread reader = new Thread(() -> {
@@ -108,15 +179,13 @@ public class AnalysisRunner implements Runnable {
 					batch[idx++] = file.next();
 					++readerSeqCount;
 					if (idx == BATCH_SIZE) {
-						for (int p = 0; p < NUM_PROCESSORS; p++) {
+						for (int p = 0; p < numProcessors; p++) {
 							procQueues[p].put(batch);
 						}
 						batch = new Sequence[BATCH_SIZE];
 						idx = 0;
 
-						// Same cadence as the single-threaded version: every
-						// 1000 reads (rounded up to 1024 by BATCH_SIZE), fire
-						// analysisUpdated only when we've crossed another 5%.
+						// Fire analysisUpdated only when the file advances another 5%.
 						if (file.getPercentComplete() >= percentComplete + 5) {
 							percentComplete = (((int) file.getPercentComplete()) / 5) * 5;
 							for (int li = 0; li < listeners.size(); li++) {
@@ -127,7 +196,7 @@ public class AnalysisRunner implements Runnable {
 				}
 				if (idx > 0) {
 					Sequence[] partial = Arrays.copyOf(batch, idx);
-					for (int p = 0; p < NUM_PROCESSORS; p++) {
+					for (int p = 0; p < numProcessors; p++) {
 						procQueues[p].put(partial);
 					}
 				}
@@ -140,9 +209,8 @@ public class AnalysisRunner implements Runnable {
 			}
 			finally {
 				seqCountHolder[0] = readerSeqCount;
-				// POISON must always be delivered, otherwise processor threads
-				// block forever on take() and the run never completes.
-				for (int p = 0; p < NUM_PROCESSORS; p++) {
+				// POISON must always be delivered or processors block on take() forever.
+				for (int p = 0; p < numProcessors; p++) {
 					try { procQueues[p].put(POISON); } catch (InterruptedException e) {
 						Thread.currentThread().interrupt();
 					}
@@ -152,9 +220,9 @@ public class AnalysisRunner implements Runnable {
 		reader.setDaemon(true);
 		reader.start();
 
-		CountDownLatch processorsDone = new CountDownLatch(NUM_PROCESSORS);
+		CountDownLatch processorsDone = new CountDownLatch(numProcessors);
 
-		for (int p = 0; p < NUM_PROCESSORS; p++) {
+		for (int p = 0; p < numProcessors; p++) {
 			final QCModule[] myModules = moduleSplits[p];
 			final ArrayBlockingQueue<Sequence[]> myQueue = procQueues[p];
 
@@ -177,9 +245,8 @@ public class AnalysisRunner implements Runnable {
 					Thread.currentThread().interrupt();
 				}
 				catch (RuntimeException e) {
-					// Don't let a misbehaving module deadlock the pipeline:
-					// drain remaining batches so the reader doesn't block on
-					// put(), and surface the failure after the join.
+					// Drain so the reader doesn't block on put(); surface the
+					// failure to listeners after join().
 					processorError[0] = e;
 					try {
 						while (myQueue.take() != POISON) { /* drain */ }

--- a/uk/ac/babraham/FastQC/Analysis/OfflineRunner.java
+++ b/uk/ac/babraham/FastQC/Analysis/OfflineRunner.java
@@ -118,7 +118,10 @@ public class OfflineRunner implements AnalysisListener {
 		
 		
 		filesRemaining = new AtomicInteger(fileGroups.length);
-				
+
+		// Let the queue size its CPU budget to the actual workload.
+		AnalysisQueue.getInstance().configure(fileGroups.length);
+
 		for (int i=0;i<fileGroups.length;i++) {
 
 			try {


### PR DESCRIPTION
I spent a while trying to get the performance improvements from my Rust rewrite back upstream into the Java distribution. After a lot of different attempts, none of which really made any difference, I gave up. Thankfully I posted about this on our Seqera Slack and @pditommaso, defender of the Java faith, stood up for Java and said that anything Rust could do, Java could do better (or as fast, anyway).

@pditommaso proceeded to try [a lot of things](https://github.com/pditommaso/FastQC/pulls) and sure enough, pulled a 3x speed improvement out of the bag.

I've now gone though all of his changes with a tooth pick and tried to separate out the different aspects and benchmark which things had what effect. The result of that was pinpointing the smallest change that made the biggest difference: parallelisation of the stream reader. I pulled that code out into a new clean branch and hammered on it to cut it down as much as possible, as well as polish and benchmark. This PR is the result of that.

### What it does

As of this PR, each file now runs through a small in-process pipeline instead of a single loop: one reader thread (gzip + FASTQ parse) feeds up to three processor threads that each own a disjoint slice of the QC modules. The modules themselves are unchanged and no module needs to become thread-safe. Despite us thinking that gzip was the bottleneck and that was that, this does indeed give a major performance boost.

### Behaviour change

The core code change is in the first commit and is really rather small. The second commit is to handle the pre-existing `-t` flag which sets threads. Previously threads = number of files processed in parallel, as FastQC was single-threaded. After the above change, each `-t` value for a new file was actually 4 more CPUs, which is not what the end user would expect.

To handle this, I tweaked how it worked and made it truly reflect the number of CPUs to use. `-t` / `-Dfastqc.threads` is now a total CPU budget, split between files in parallel (outer concurrency) and the per-file pipeline (inner concurrency). It defaults to `min(4 × num_files, available_cpus)`. 

| Invocation | Before | After |
|---|---|---|
| `-t 1` | 1 core / file | 1 core / file (sequential path, unchanged) |
| `-t N` (N > 1) | up to N files in parallel, 1 core each | total budget of N cores across files × pipeline |
| no `-t` | 1 file at a time, 1 core | up to 4 cores / file |

### Benchmark

To validate the results I ran a set of benchmarks. Full report with results, and also discussing the changes in the PR and why they work, is here: [report.html](https://github.com/user-attachments/files/28094295/report.html)

Note that all outputs are byte-identical to master across every run.

To avoid downloading + opening the HTML to view, here's a full-page screenshot which you can squint at in the GitHub UI, if you prefer:

<details><summary>Report (screenshot)</summary>

<img alt="_Volumes_T7%20Shield_fastqc-bench_results_report html" src="https://github.com/user-attachments/assets/0294cf38-4ccf-4886-a249-b72230d2adb8" />

</details>