### PR TITLE
Refine mean/median sequence length output

### DIFF
--- a/test/integration/FileContentsTest_complex_fastqc_data.approved.txt
+++ b/test/integration/FileContentsTest_complex_fastqc_data.approved.txt
@@ -6,8 +6,9 @@ File type	Conventional base calls
 Encoding	Illumina 1.5
 Total Sequences	5
 Total Bases	80 bp
-Sequences flagged as poor quality	0
 Sequence length	16
+Mean Length	16.0
+Median Length	16
 %GC	50
 >>END_MODULE
 >>Per base sequence quality	pass

--- a/test/integration/FileContentsTest_complex_fastqc_report.approved.html
+++ b/test/integration/FileContentsTest_complex_fastqc_report.approved.html
@@ -248,11 +248,15 @@
        <td>80 bp</td>
       </tr>
       <tr>
-       <td>Sequences flagged as poor quality</td>
-       <td>0</td>
+       <td>Sequence length</td>
+       <td>16</td>
       </tr>
       <tr>
-       <td>Sequence length</td>
+       <td>Mean Length</td>
+       <td>16.0</td>
+      </tr>
+      <tr>
+       <td>Median Length</td>
        <td>16</td>
       </tr>
       <tr>

--- a/test/integration/FileContentsTest_minimal_fastqc_data.approved.txt
+++ b/test/integration/FileContentsTest_minimal_fastqc_data.approved.txt
@@ -6,8 +6,9 @@ File type	Conventional base calls
 Encoding	Illumina 1.5
 Total Sequences	1
 Total Bases	16 bp
-Sequences flagged as poor quality	0
 Sequence length	16
+Mean Length	16.0
+Median Length	16
 %GC	0
 >>END_MODULE
 >>Per base sequence quality	pass

--- a/test/integration/FileContentsTest_minimal_fastqc_report.approved.html
+++ b/test/integration/FileContentsTest_minimal_fastqc_report.approved.html
@@ -248,11 +248,15 @@
        <td>16 bp</td>
       </tr>
       <tr>
-       <td>Sequences flagged as poor quality</td>
-       <td>0</td>
+       <td>Sequence length</td>
+       <td>16</td>
       </tr>
       <tr>
-       <td>Sequence length</td>
+       <td>Mean Length</td>
+       <td>16.0</td>
+      </tr>
+      <tr>
+       <td>Median Length</td>
        <td>16</td>
       </tr>
       <tr>

--- a/uk/ac/babraham/FastQC/Modules/BasicStats.java
+++ b/uk/ac/babraham/FastQC/Modules/BasicStats.java
@@ -21,6 +21,7 @@ package uk.ac.babraham.FastQC.Modules;
 
 import java.awt.BorderLayout;
 import java.io.IOException;
+import java.util.Locale;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -249,7 +250,8 @@ public class BasicStats extends AbstractQCModule {
 						}
 						
 					case 6 :
-						return ""+(totalBases/actualCount);
+						if (actualCount == 0) return "0.0";
+						return String.format(Locale.ROOT, "%.1f", (double)totalBases/actualCount);
 					case 7 :
 						if (lengthDist == null) {
 							return "NA";

--- a/uk/ac/babraham/FastQC/Modules/SequenceLengthDistribution.java
+++ b/uk/ac/babraham/FastQC/Modules/SequenceLengthDistribution.java
@@ -56,29 +56,37 @@ public class SequenceLengthDistribution extends AbstractQCModule {
 	}
 	
 	public int medianLength() {
-		// We need to go through the data twice - once to get the 
-		// total number of reads and the second time to find the 
-		// length at the 50th percent rank
-		
 		long total = 0;
 		for (int i=0;i<lengthCounts.length;i++) {
 			total += lengthCounts[i];
 		}
-		
-		long rank50 = total/2;
 
+		if (total == 0) return 0;
+
+		// For an odd number of reads the median is the single central value.
+		// For an even number it's the mean of the two central values, rounded up.
+		if (total % 2 == 1) {
+			return lengthAtRank(total/2);
+		}
+		else {
+			long lo = lengthAtRank((total/2) - 1);
+			long hi = lengthAtRank(total/2);
+			return (int)((lo + hi + 1) / 2);
+		}
+	}
+
+	// Returns the length at the given zero-based rank in ascending order of length.
+	private int lengthAtRank(long rank) {
 		long runningCount = 0;
 		for (int i=0;i<lengthCounts.length;i++) {
-			if (runningCount + lengthCounts[i] > rank50) {
-				return(i);
-			}
-			
 			runningCount += lengthCounts[i];
+			if (runningCount > rank) {
+				return i;
+			}
 		}
-		
-		throw new RuntimeException("Should never fail to find a value above the 50th percentile");
-	}	
-	
+		throw new RuntimeException("Should never fail to find a value above the rank");
+	}
+
 	private synchronized void calculateDistribution () {
 		int maxLen = 0;
 		int minLen = -1;


### PR DESCRIPTION
Builds on #203 / 54b336e (mean & median sequence length). Two small refinements plus the test snapshots that commit didn't include.

## Changes

**1. Mean Length → 1 decimal place** (`BasicStats.java`)

Currently the mean is integer division (`totalBases/actualCount`), so a 150.7 bp mean prints as `150`. This reports it to 1 d.p. instead:

```java
if (actualCount == 0) return "0.0";
return String.format(Locale.ROOT, "%.1f", (double)totalBases/actualCount);
```

(`Locale.ROOT` keeps the decimal separator as `.` regardless of system locale; the zero guard avoids an integer divide-by-zero on empty input.)

**2. Median tie-breaking** (`SequenceLengthDistribution.medianLength()`)

For an **even** number of reads, the current code returns the upper of the two central values. This uses the standard definition — the mean of the two central values, rounded up:

- Odd N: the single central value.
- Even N: `(lo + hi + 1) / 2`.

Also added a `total == 0` guard (returns 0) so an empty distribution doesn't throw. Identical to current behaviour for uniform-length (short-read) data; differs only on even read counts with two distinct central lengths.

**3. Test snapshots** (`FileContentsTest_{minimal,complex}_fastqc_*`)

Updated the approved data + HTML files for the new `Mean Length` / `Median Length` rows. The HTML snapshots are edited in place so the embedded base64 chart images are left untouched (rendering differs per OS).

## Notes

- Labels (`Mean Length` / `Median Length`) and filtered-sequence handling are left exactly as in 54b336e.
- Heads-up: the approved `fastqc_data.txt` files still carry `##FastQC 0.12.2.devel` while the build now emits `0.13.0.devel` — a pre-existing version-string mismatch in the snapshots, independent of this change. Left as-is to keep this PR scoped; happy to bump it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)