### PR TITLE
Use Phred+33 for BAM/SAM quality encoding rather than guessing from the data

### DIFF
--- a/uk/ac/babraham/FastQC/Modules/BasicStats.java
+++ b/uk/ac/babraham/FastQC/Modules/BasicStats.java
@@ -46,6 +46,7 @@ public class BasicStats extends AbstractQCModule {
 	private long aCount = 0;
 	private long tCount = 0;
 	private char lowestChar = 126;
+	private PhredEncoding fileEncoding = null;
 	private String fileType = null;
 	private SequenceLengthDistribution lengthDist = null;
 	
@@ -80,6 +81,7 @@ public class BasicStats extends AbstractQCModule {
 		cCount = 0;
 		aCount = 0;
 		tCount = 0;
+		fileEncoding = null;
 	}
 
 	public String name() {
@@ -95,6 +97,7 @@ public class BasicStats extends AbstractQCModule {
 	public void processSequence(Sequence sequence) {
 
 		if (name == null) setFileName(sequence.file().name());
+		if (fileEncoding == null) fileEncoding = sequence.file().getPhredEncoding();
 				
 		actualCount++;
 		
@@ -237,7 +240,9 @@ public class BasicStats extends AbstractQCModule {
 					switch (rowIndex) {
 					case 0 : return name;
 					case 1 : return fileType;
-					case 2 : return PhredEncoding.getFastQEncodingOffset(lowestChar);
+					case 2 :
+						if (fileEncoding != null) return fileEncoding;
+						return PhredEncoding.getFastQEncodingOffset(lowestChar);
 					case 3 : return ""+actualCount;
 					case 4 : return BasicStats.formatLength(totalBases);
 					case 5 :

--- a/uk/ac/babraham/FastQC/Modules/PerBaseQualityScores.java
+++ b/uk/ac/babraham/FastQC/Modules/PerBaseQualityScores.java
@@ -44,6 +44,7 @@ public class PerBaseQualityScores extends AbstractQCModule {
 	int low = 0;
 	int high = 0;
 	PhredEncoding encodingScheme;
+	private PhredEncoding fileEncoding = null;
 	private boolean calculated = false;
 		
 	public JPanel getResultsPanel() {
@@ -68,7 +69,12 @@ public class PerBaseQualityScores extends AbstractQCModule {
 	private synchronized void getPercentages () {
 		
 		char [] range = calculateOffsets();
-		encodingScheme = PhredEncoding.getFastQEncodingOffset(range[0]);
+		if (fileEncoding != null) {
+			encodingScheme = fileEncoding;
+		}
+		else {
+			encodingScheme = PhredEncoding.getFastQEncodingOffset(range[0]);
+		}
 		low = 0;
 		high = range[1] - encodingScheme.offset();
 		if (high < 35) {
@@ -129,6 +135,7 @@ public class PerBaseQualityScores extends AbstractQCModule {
 	public void processSequence(Sequence sequence) {
 		
 		calculated = false;
+		if (fileEncoding == null) fileEncoding = sequence.file().getPhredEncoding();
 		String qual = sequence.getQualityString();
 		int qualLen = qual.length();
 		if (qualityCounts.length < qualLen) {
@@ -153,6 +160,7 @@ public class PerBaseQualityScores extends AbstractQCModule {
 	
 	public void reset () {
 		qualityCounts = new QualityCount[0];
+		fileEncoding = null;
 	}
 
 	public String description() {

--- a/uk/ac/babraham/FastQC/Modules/PerSequenceQualityScores.java
+++ b/uk/ac/babraham/FastQC/Modules/PerSequenceQualityScores.java
@@ -37,6 +37,7 @@ public class PerSequenceQualityScores extends AbstractQCModule {
 	private double [] qualityDistribution = null;
 	private int [] xCategories = new int[0];
 	private char lowestChar = 126;
+	private PhredEncoding fileEncoding = null;
 	private int maxCount = 0;
 	private int mostFrequentScore;
 	private boolean calculated = false;
@@ -58,7 +59,13 @@ public class PerSequenceQualityScores extends AbstractQCModule {
 	
 	private synchronized void calculateDistribution () {
 		
-		PhredEncoding encoding = PhredEncoding.getFastQEncodingOffset(lowestChar);
+		PhredEncoding encoding;
+		if (fileEncoding != null) {
+			encoding = fileEncoding;
+		}
+		else {
+			encoding = PhredEncoding.getFastQEncodingOffset(lowestChar);
+		}
 		
 		Integer [] rawScores = averageScoreCounts.keySet().toArray(new Integer [0]);
 		Arrays.sort(rawScores);
@@ -88,6 +95,7 @@ public class PerSequenceQualityScores extends AbstractQCModule {
 
 	public void processSequence(Sequence sequence) {
 				
+		if (fileEncoding == null) fileEncoding = sequence.file().getPhredEncoding();
 		String qual = sequence.getQualityString();
 		int qualLen = qual.length();
 		int averageQuality = 0;
@@ -117,6 +125,7 @@ public class PerSequenceQualityScores extends AbstractQCModule {
 	public void reset () {
 		averageScoreCounts.clear();
 		lowestChar = 126;
+		fileEncoding = null;
 		maxCount = 0;
 		calculated = false;
 	}

--- a/uk/ac/babraham/FastQC/Modules/PerTileQualityScores.java
+++ b/uk/ac/babraham/FastQC/Modules/PerTileQualityScores.java
@@ -44,6 +44,7 @@ public class PerTileQualityScores extends AbstractQCModule {
 	private int [] tiles;
 	private int high = 0;
 	PhredEncoding encodingScheme;
+	private PhredEncoding fileEncoding = null;
 	private boolean calculated = false;
 	
 	private long totalCount = 0;
@@ -76,7 +77,12 @@ public class PerTileQualityScores extends AbstractQCModule {
 	private synchronized void getPercentages () {
 
 		char [] range = calculateOffsets();
-		encodingScheme = PhredEncoding.getFastQEncodingOffset(range[0]);
+		if (fileEncoding != null) {
+			encodingScheme = fileEncoding;
+		}
+		else {
+			encodingScheme = PhredEncoding.getFastQEncodingOffset(range[0]);
+		}
 		high = range[1] - encodingScheme.offset();
 		if (high < 35) {
 			high = 35;
@@ -193,6 +199,7 @@ public class PerTileQualityScores extends AbstractQCModule {
 		}
 				
 		calculated = false;
+		if (fileEncoding == null) fileEncoding = sequence.file().getPhredEncoding();
 
 		// Try to find the tile id.  This can come in one of two forms:
 		//		@HWI-1KL136:211:D1LGAACXX:1:1101:18518:48851 3:N:0:ATGTCA
@@ -310,6 +317,7 @@ public class PerTileQualityScores extends AbstractQCModule {
 	public void reset () {
 		totalCount = 0;
 		perTileQualityCounts = new HashMap<Integer, QualityCount[]>();
+		fileEncoding = null;
 	}
 
 	public String description() {

--- a/uk/ac/babraham/FastQC/Sequence/BAMFile.java
+++ b/uk/ac/babraham/FastQC/Sequence/BAMFile.java
@@ -34,6 +34,8 @@ import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 
+import uk.ac.babraham.FastQC.Sequence.QualityEncoding.PhredEncoding;
+
 
 public class BAMFile implements SequenceFile {
 
@@ -86,6 +88,14 @@ public class BAMFile implements SequenceFile {
 
 	public boolean isColorspace () {
 		return false;
+	}
+		
+	public PhredEncoding getPhredEncoding () {
+		// BAM/SAM base qualities are always Phred+33 once htsjdk has decoded
+		// them, so there is nothing to infer from the quality data.  Guessing
+		// from the lowest seen character misdetects Illumina 1.5 whenever a
+		// file contains no base below Q31.
+		return PhredEncoding.SANGER;
 	}
 		
 	public boolean hasNext() {

--- a/uk/ac/babraham/FastQC/Sequence/QualityEncoding/PhredEncoding.java
+++ b/uk/ac/babraham/FastQC/Sequence/QualityEncoding/PhredEncoding.java
@@ -27,6 +27,8 @@ public class PhredEncoding {
 	private static final int SANGER_ENCODING_OFFSET = 33;
 	private static final int ILLUMINA_1_3_ENCODING_OFFSET = 64;
 	
+	public static final PhredEncoding SANGER = new PhredEncoding("Sanger / Illumina 1.9", SANGER_ENCODING_OFFSET);
+	
 	public static PhredEncoding getFastQEncodingOffset (char lowestChar) {
 		if (lowestChar < 33) {
 			throw new IllegalArgumentException("No known encodings with chars < 33 (Yours was '"+lowestChar+"' with value "+(int)lowestChar+")");

--- a/uk/ac/babraham/FastQC/Sequence/SequenceFile.java
+++ b/uk/ac/babraham/FastQC/Sequence/SequenceFile.java
@@ -21,6 +21,8 @@ package uk.ac.babraham.FastQC.Sequence;
 
 import java.io.File;
 
+import uk.ac.babraham.FastQC.Sequence.QualityEncoding.PhredEncoding;
+
 public interface SequenceFile {
 
 	public boolean hasNext();
@@ -29,5 +31,13 @@ public interface SequenceFile {
 	public String name();
 	public int getPercentComplete();
 	public File getFile();
+	
+	/**
+	 * The quality encoding fixed by the file format, or null if the
+	 * encoding has to be inferred from the quality data.
+	 */
+	public default PhredEncoding getPhredEncoding() {
+		return null;
+	}
 	
 }


### PR DESCRIPTION
Fixes #209.

BAM/SAM base qualities are always Phred+33 once htsjdk has decoded them (`getBaseQualityString()`), but the encoding was inferred from the lowest quality character seen anyway. BAM/SAM files with no base below Q31 were misdetected as Illumina 1.5.

Changes:

- `SequenceFile` gains a `getPhredEncoding()` default method returning the encoding fixed by the file format, or null to infer as before.
- `BAMFile` overrides it to return a new `PhredEncoding.SANGER` constant.
- The four modules that call `getFastQEncodingOffset()` (Basic Statistics and the per base / per sequence / per tile quality scores) pick up the file's encoding in `processSequence()`, use it when set, and clear it in `reset()` since `AnalysisRunner` reuses module instances.

FastQ files are unaffected.

Tested on the reproduction case from https://github.com/ewels/FastQC-Rust/issues/6: an unaligned BAM with every base at Q40 now reports `Sanger / Illumina 1.9` with a base 1 mean of 40.0, where it previously reported `Illumina 1.5` and 9.0. The same reads as FastQ still detect as Illumina 1.5, unchanged.